### PR TITLE
ユーザ削除はTeamのオーナか自分、editもオーナ feature/issues#64

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_team, only: %i[show edit update destroy]
+  before_action :not_authorized, only: %i[edit destroy]
 
   def index
     @teams = Team.all
@@ -55,5 +56,11 @@ class TeamsController < ApplicationController
 
   def team_params
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
+  end
+
+  def not_authorized
+    if current_user.id != @team.owner_id
+      redirect_to root_path
+    end
   end
 end

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% if current_user.id == @team.owner_id %>
+              <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %>            
           </div>
 
           <div class="col-md-8">
@@ -41,7 +43,11 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <td>
+                        <% if current_user.id == @team.owner_id || current_user.id == assign.user_id %>
+                          <%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %>
+                        <% end %>
+                      </td>                      
                     </tr>
                   <% end %>
                 </tbody>


### PR DESCRIPTION
- [x] Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
- [x]  TeamのeditはTeamのリーダー（オーナー）のみができるようにすること

という仕様に変更が完了しました。pull requestを作成しました。ご確認を宜しくお願いいたします。
